### PR TITLE
git: Update gitlint to be generic

### DIFF
--- a/.github/actions/gitlint/action.yml
+++ b/.github/actions/gitlint/action.yml
@@ -18,8 +18,8 @@ inputs:
     description: "Pull Request number used to fetch commits"
     required: true
   base-branch:
-    description: "Base branch to compare commits against (default: origin/main)"
-    default: "origin/main"
+    description: "Base branch to compare commits against (default: main)"
+    default: "main"
     required: false
 runs:
   using: "docker"
@@ -29,11 +29,12 @@ runs:
     - -c
     - |
       git config --global --add safe.directory /github/workspace && \
-      git fetch origin +refs/heads/main:refs/remotes/origin/main && \
+      git fetch origin +refs/heads/${{ inputs.base-branch }}:refs/remotes/origin/${{ inputs.base-branch }} && \
       git fetch origin +refs/pull/${{ inputs.pr-number }}/head && \
-      if ! gitlint --commits origin/main..HEAD; then \
+      if ! gitlint --commits origin/${{ inputs.base-branch }}..HEAD; then \
         echo -e "\nWARNING: Your commit message does not follow the required format." && \
-        echo "Formatting rules: https://eclipse-score.github.io/score/process/guidance/git/index.html" && \
+        echo "The tool gitlint is used to check the compliance with the rules described here:" && \
+        echo -e "\nhttps://github.com/eclipse-score/module_template/blob/main/.gitlint" && \
         echo -e "To fix your commit message, run:\n" && \
         echo " git commit --amend" && \
         echo "Then update your commit (fix gitlint warnings). Finally, force-push:" && \

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,37 @@
+# Available rules:
+#
+#   T1: title-max-length
+#   T2: title-trailing-whitespace
+#   T3: title-trailing-punctuation (disabled)
+#   T4: title-hard-tab
+#   T5: title-must-not-contain-word (disabled)
+#   T6: title-leading-whitespace
+#   T7: title-match-regex
+#   B1: body-max-line-length (disabled)
+#   B2: body-trailing-whitespace
+#   B3: body-hard-tab
+#   B4: body-first-line-empty
+#   B5: body-min-length (disabled)
+#   B6: body-is-missing
+#   B7: body-changed-file-mention (disabled)
+#
+# See http://jorisroovers.github.io/gitlint/rules/ for a full description of the rules.
+
+# Ignore some default rules and enable regex style searching
+[general]
+ignore=T3,T5,B1,B5,B7
+regex-style-search=true
+
+# Maximum length of the title
+[title-max-length]
+line-length=72
+
+[title-match-regex]
+regex=^[a-z_-]+: .+$
+
+# First line of the commit message body must be empty. (second line of the commit message)
+[body-first-line-empty]
+
+#Ignores the title if it starts with Revert or Merge
+[ignore-by-title]
+regex=(^Revert |^Merge )


### PR DESCRIPTION
Use correct link to docs in gitlint error message. 
Use base-branch input instead of hardcoded main.
Add .gitlint.