### PR TITLE
Don't fetch starpls_server via bazel and fix vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,20 +2,17 @@
     "recommendations": [
         // Editing *.drawio.svg files directly in VS Code
         "hediet.vscode-drawio",
-
         // Some convenient extensions for editing reStructuredText files
         "lextudio.restructuredtext",
-
         // Linting and live preview for score docs
         "swyddfa.esbonio",
-
         // ErrorLens highlights errors and warnings in your code / docs
         "usernamehw.errorlens",
-
         // Linting and formatting for Python (LSP via ruff server)
         "charliermarsh.ruff",
-
         // BasedPyright for python various type checking improvements and pylance features
         "detachhead.basedpyright",
+        // Bazel BUILD integration
+        "bazelbuild.vscode-bazel",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,12 +5,10 @@
     "files.trimTrailingWhitespace": true,
     "editor.insertSpaces": true,
     "editor.tabCompletion": "on",
-
     // Default for any filetype
     "editor.rulers": [
         99
     ],
-
     // Exclude build, temp and cache folders
     "files.watcherExclude": {
         ".*/**": true,
@@ -19,7 +17,6 @@
         ".venv*/**": true,
         "_build/**": true,
     },
-
     // Python Settings
     // Exclude build, temp and cache folders
     "python.analysis.exclude": [
@@ -42,13 +39,13 @@
         },
         "editor.defaultFormatter": "charliermarsh.ruff",
     },
-
     // Markdown Settings
     "[markdown]": {
         // We mostly write markdown in some combination with python,
         // so we use the same rulers as python.
         "editor.rulers": [
-            79, 99
+            79,
+            99
         ]
     },
 
@@ -61,6 +58,12 @@
     // RST Settings
     "[restructuredtext]": {
         "editor.tabSize": 3,
+    },
+    // Patch files
+    "[diff]": {
+        "files.insertFinalNewline": false,
+        "files.trimFinalNewlines": false,
+        "files.trimTrailingWhitespace": false,
     },
     //
     //
@@ -80,9 +83,11 @@
     //
     //
     // Esbonio 1.x (Preview)
-    "esbonio.sphinx.pythonCommand": [
-        ".venv_docs/bin/python"
-    ],
+    "esbonio.sphinx.pythonCommand": {
+        "command": [
+            ".venv_docs/bin/python"
+        ]
+    },
     "esbonio.sphinx.buildCommand": [
         "docs",
         "_build",
@@ -99,8 +104,13 @@
         "--ignore-glob=bazel-*/*",
         "--ignore-glob=.venv_docs/*",
         "--ignore-glob=_build/*",
-
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
+    "clangd.arguments": [
+        "--compile-commands-dir=${workspaceFolder}/",
+        "--pretty",
+        "--background-index",
+        "--query-driver=/var/cache/bazel/*/execroot/_main/external/toolchains_llvm++llvm+llvm_toolchain/bin/cc_wrapper.sh"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,13 +48,6 @@
             99
         ]
     },
-
-    "bazel.lsp.command": "bazel",
-    "bazel.lsp.args": [
-        "run",
-        "//:starpls_server"
-    ],
-
     // RST Settings
     "[restructuredtext]": {
         "editor.tabSize": 3,

--- a/BUILD
+++ b/BUILD
@@ -12,13 +12,8 @@
 # *******************************************************************************
 
 load("@score_docs_as_code//:docs.bzl", "docs")
-load("@score_tooling//:defs.bzl", "copyright_checker", "dash_license_checker", "setup_starpls", "use_format_targets")
+load("@score_tooling//:defs.bzl", "copyright_checker", "dash_license_checker", "use_format_targets")
 load("//:project_config.bzl", "PROJECT_CONFIG")
-
-setup_starpls(
-    name = "starpls_server",
-    visibility = ["//visibility:public"],
-)
 
 copyright_checker(
     name = "copyright",


### PR DESCRIPTION
Don't fetch starpls via bazel and use the one installed on the system or devcontainer instead.

Also clean up and fix some other vscode settings.

## Related ticket

Addresses eclipse-score/tooling#79 (bugfix ticket)
