### PR TITLE
Centralize required checks into few workflows

### DIFF
--- a/.github/workflows/bzlmod-lock.yml
+++ b/.github/workflows/bzlmod-lock.yml
@@ -14,10 +14,7 @@ name: Bzlmod Lockfile Check
 permissions:
   contents: read
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  merge_group:
-    types: [checks_requested]
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: CI
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+jobs:
+  pre-commit:
+    secrets: inherit
+    uses: ./.github/workflows/pre-commit.yml
+  bzlmod-lock:
+    secrets: inherit
+    uses: ./.github/workflows/bzlmod-lock.yml
+  copyright:
+    secrets: inherit
+    uses: ./.github/workflows/copyright.yml
+  format:
+    secrets: inherit
+    uses: ./.github/workflows/format.yml
+  gitlint:
+    secrets: inherit
+    uses: ./.github/workflows/gitlint.yml
+  # check if PR can be enqueued to the merge queue or merged to main
+  # individual jobs are skipped in their respective workflow files depending on the event type,
+  # so we can just check the outcomes of all jobs here without checking the event type again.
+  # This job fails, if any of the required checks failed.
+  # Skipped jobs are not a failure.
+  can_merge:
+    name: ci/can_merge
+    if: always()
+    needs:
+      - pre-commit
+      - bzlmod-lock
+      - copyright
+      - format
+      - gitlint
+    permissions:
+      actions: read
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          NEEDS_JSON: "${{toJSON(needs)}}"
+        name: Transform outcomes
+        run: |
+          echo "ALL_SUCCESS=$(echo "$NEEDS_JSON" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >>$GITHUB_ENV
+      - name: check
+        run: |
+          [ $ALL_SUCCESS == true ]
+  # workaround to get running merge queue checks visible in the PR checks list, as GitHub does not show merge group check runs in the UI.
+  can_see_status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Immediate success for improved visibility on github merge queue
+        run: true

--- a/.github/workflows/ci_pull_request_target.yml
+++ b/.github/workflows/ci_pull_request_target.yml
@@ -1,0 +1,64 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: CI (context of the base branch)
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+jobs:
+  docs:
+    secrets: inherit
+    uses: ./.github/workflows/docs.yml
+    permissions:
+      contents: write
+      pages: write
+      pull-requests: write
+      id-token: write
+  license_check:
+    secrets: inherit
+    uses: ./.github/workflows/license_check.yml
+    permissions:
+      pull-requests: write
+      issues: write
+  # check if PR can be enqueued to the merge queue or merged to main
+  # individual jobs are skipped in their respective workflow files depending on the event type,
+  # so we can just check the outcomes of all jobs here without checking the event type again.
+  # This job fails, if any of the required checks failed.
+  # Skipped jobs are not a failure.
+  can_merge:
+    name: ci_pull_request_target/can_merge
+    if: always()
+    needs:
+      - docs
+      - license_check
+    permissions:
+      actions: read
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          NEEDS_JSON: "${{toJSON(needs)}}"
+        name: Transform outcomes
+        run: |
+          echo "ALL_SUCCESS=$(echo "$NEEDS_JSON" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >>$GITHUB_ENV
+      - name: check
+        run: |
+          [ $ALL_SUCCESS == true ]
+  # workaround to get running merge queue checks visible in the PR checks list, as GitHub does not show merge group check runs in the UI.
+  can_see_status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Immediate success for improved visibility on github merge queue
+        run: true

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -13,10 +13,7 @@
 
 name: Copyright checks
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  merge_group:
-    types: [checks_requested]
+  workflow_call:
 jobs:
   copyright-check:
     uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,13 +20,10 @@ permissions:
   id-token: write
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize] # Allows forks to trigger the docs build
   push:
     branches:
       - main
-  merge_group:
-    types: [checks_requested]
+  workflow_call:
 
 jobs:
   build-docs:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,10 +14,7 @@
 name: Formatting checks
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  merge_group:
-    types: [checks_requested]
+  workflow_call:
 
 jobs:
   formatting-check:

--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -13,8 +13,7 @@
 
 name: Gitlint check
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
 jobs:
   lint-commits:
     name: check-commit-messages

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -13,10 +13,7 @@
 
 name: License check preparation
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize]
-  merge_group:
-    types: [checks_requested]
+  workflow_call:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,8 +12,7 @@
 # *******************************************************************************
 name: pre-commit
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+  workflow_call:
 jobs:
   self_test:
     name: 🔬 Self Test


### PR DESCRIPTION
When adding or removing required checks settings have to be changed either in Github UI or Otterdog configuration, which requires review by a different set of people and might delay progress. On top of that this makes finding a uniform configuration among many repos harder.

The `can_merge` jobs depend on all required workflows and fail if any of their dependencies fail.

If expensive workflows like cross compilation are added the decision whether to run them or not, only needs to be done in one of the ci*.yml files. My current proposal is to only run the expensive jobs in the merge_queue and trigger them in the pull request, if labels like `test-qnx` or `test-cross` are set. See https://github.com/eclipse-score/inc_someip_gateway/blob/8fda2442a3ac6b417dee99076f88239569178ead/.github/workflows/ci_pull_request_target.yml#L22-L30 as an example.

The [cicd-workflows/qnx_build.yml](https://github.com/eclipse-score/cicd-workflows/blob/main/.github/workflows/qnx-build.yml) has already been adapted to not require approval, when being run in a merge queue. If applied to all repos this should hopefully reduce the amount of workflow approval E-Mails a lot.

The design is based on this blogpost: https://boinkor.net/2023/11/neat-github-actions-patterns-for-github-merge-queues/ and how [communication](https://github.com/eclipse-score/communication/) handles QNX tests now with labels and the merge queue. It has been adapted by [inc_someip_gateway](https://github.com/eclipse-score/inc_someip_gateway) as well.