### PR TITLE
docs: Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+<!--
+*******************************************************************************
+Copyright (c) 2026 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0
+
+SPDX-License-Identifier: Apache-2.0
+*******************************************************************************
+-->
+
+# Security Policy
+
+<!--
+    THIS IS A TEMPLATE THAT YOU MUST MODIFIY FOR USE BY YOUR PROJECT.
+
+    Adapt this template as required:
+
+    * Remove content that does not make sense for your project
+    * Replace <organization> and <repository> with values for your project
+    * Remove the comments
+
+    For any questions about implementing security best practices, contact the
+    Eclipse Foundation Security Team at security@eclipse-foundation.org
+-->
+
+This Eclipse Foundation Project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
+
+## How To Report a Vulnerability
+
+If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
+
+Instead, report it using one of the following ways:
+
+* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+* Report a [vulnerability](https://github.com/eclipse-score/score/security/advisories/new) directly via private vulnerability reporting on GitHub <!-- EDIT THIS LINE IF YOUR PROJECT USES GITHUB ADVISORIES; DELETE IT OTHERWISE -->
+
+You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+* Affected version(s)
+* Impact of the issue, including how an attacker might exploit the issue
+* Step-by-step instructions to reproduce the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Full paths of source file(s) related to the manifestation of the issue
+* Configuration required to reproduce the issue
+* Log files that are related to this issue (if possible)
+* Proof-of-concept or exploit code (if possible)
+
+This information will help us triage your report more quickly.
+
+<!-- ## Supported Versions -->
+
+<!--
+    Which releases of the project's software are actively maintained and receive security updates?
+-->
+<!-- Supported versions are:
+
+* there are no supported versions of this project yet -->


### PR DESCRIPTION
Eclipse asked us to add SECURITY.md to S-CORE: https://www.eclipse.org/lists/eclipse.org-committers/msg01582.html

Let's start with the module_template and spread it to other repos if agreed on.