### PR TITLE
Bug fix: correct link in fdr checklist

### DIFF
--- a/docs/safety_mgt/module_safety_analysis_fdr.rst
+++ b/docs/safety_mgt/module_safety_analysis_fdr.rst
@@ -60,7 +60,7 @@ Please note that it is mandatory to fill in the "passed" column with "yes" or "n
         - Comment
 
       * - Gen 1
-        - Are the safety analysis performed according to the defined process and templates? See :need:`gd_req__saf_structure` and also :need:`doc__feature_name_fmea` and :need:`doc__feature_name_dfa`
+        - Are the safety analysis performed according to the defined process and templates? See :need:`gd_req__saf_structure` and also :need:`gd_temp__feat_saf_fmea` and :need:`gd_temp__feat_saf_dfa`
         - [YES | NO ]
         - :need:`[[title]] <std_req__iso26262__analysis_841>`, :need:`[[title]] <std_req__iso26262__analysis_849>`, :need:`[[title]] <std_req__iso26262__analysis_8410>`, :need:`[[title]] <std_req__iso26262__analysis_748>`
         - <Rationale for result>


### PR DESCRIPTION
Previous links pointed to module_template artefacts. This would require a dependency of every module repo to the module_template repo, which is not needed.