### PR TITLE
remove double declaration of comp

### DIFF
--- a/score/component_example/docs/architecture/component_architecture.rst
+++ b/score/component_example/docs/architecture/component_architecture.rst
@@ -75,43 +75,39 @@ The components are designed to cover the expectations from the feature architect
 
 A component can optional also consist of lower level components to further structure the architecture. The component and its static views can also optionally use interfaces provided by other components.
 
-.. comp:: Component Name
-   :id: comp__mod_temp_component_name_template
-   :security: YES
-   :safety: ASIL_B
-   :status: valid
-   :version: 1
-   :consists_of: comp__mod_temp_archex_sub_component_1, comp__mod_temp_archex_sub_component_2, comp__mod_temp_archex_sub_component_3
-   :belongs_to: feat__mtef
+.. code-block:: rst
 
-.. comp_arc_sta:: Component Name (Static View)
-   :id: comp_arc_sta__mod_temp_component_name__sv
-   :security: YES
-   :safety: ASIL_B
-   :status: valid
-   :version: 1
-   :belongs_to: comp__mod_temp_component_name_template
-   :fulfils: comp_req__mod_temp_component_name__some_title
+   .. comp_arc_sta:: Component Name (Static View)
+      :id: comp_arc_sta__mod_temp_component_name__sv
+      :security: YES
+      :safety: ASIL_B
+      :status: valid
+      :version: 1
+      :belongs_to: comp__mod_temp_component_name_template
+      :fulfils: comp_req__mod_temp_component_name__some_title
 
-   .. needarch::
-      :scale: 50
-      :align: center
+      .. needarch::
+         :scale: 50
+         :align: center
 
-      {{ draw_component(need(), needs) }}
+         {{ draw_component(need(), needs) }}
 
 Dynamic Architecture
 --------------------
 
-.. comp_arc_dyn:: Dynamic View
-   :id: comp_arc_dyn__mod_temp_component_name__dv
-   :security: YES
-   :safety: ASIL_B
-   :status: valid
-   :version: 1
-   :belongs_to: comp__mod_temp_component_name_template
-   :fulfils: comp_req__mod_temp_component_name__some_title
+.. code-block:: rst
 
-   Put here a sequence diagram
+   .. comp_arc_dyn:: Dynamic View
+      :id: comp_arc_dyn__mod_temp_component_name__dv
+      :security: YES
+      :safety: ASIL_B
+      :status: valid
+      :version: 1
+      :belongs_to: comp__mod_temp_component_name_template
+      :fulfils: comp_req__mod_temp_component_name__some_title
+
+      Put here a sequence diagram
+
 
 Interfaces
 ----------
@@ -128,16 +124,20 @@ Interfaces
 Internal Components
 -------------------
 
-.. comp_arc_sta:: Component Name Static View
-   :id: comp_arc_sta__mod_temp_component_name__2
-   :status: valid
-   :version: 1
-   :safety: ASIL_B
-   :security: YES
-   :fulfils: comp_req__mod_temp_component_name__some_title
-   :belongs_to: comp__mod_temp_component_example_2
+<If a component is further split into internal components, the internal components are described here.>
 
-   No architecture but detailed design
+.. code-block:: rst
+
+   .. comp_arc_sta:: Component Name Static View
+      :id: comp_arc_sta__mod_temp_component_name__2
+      :status: valid
+      :version: 1
+      :safety: ASIL_B
+      :security: YES
+      :fulfils: comp_req__mod_temp_component_name__some_title
+      :belongs_to: comp__mod_temp_component_example_2
+
+      No architecture but detailed design
 
 .. note::
    Architecture can be split into multiple files. At component level the public interfaces to be used by the user and tester to be shown.

--- a/score/component_example/docs/index.rst
+++ b/score/component_example/docs/index.rst
@@ -34,10 +34,10 @@
       :id: comp__mod_temp_component_name_template
       :security: YES
       :safety: ASIL_B
-      :status: invalid
-      :implements: logic_arc_int__feature_name__interface_name1
-      :consists_of: comp__component_name_internal_1, comp__component_name_internal_2, comp__component_name_internal_3
-      :belongs_to: feat__feature_name
+      :status: valid
+      :implements: logic_arc_int__example_feature__if_1
+      :version: 1
+      :belongs_to: feat__mtef
 
 .. attention::
     The above directives must be updated according to your Component.

--- a/score/component_example/docs/requirements/requirements.rst
+++ b/score/component_example/docs/requirements/requirements.rst
@@ -38,19 +38,21 @@ Component <Name> Requirements
 Functional Requirements
 -----------------------
 
-.. comp_req:: Some Title
-   :id: comp_req__mod_temp_component_name__some_title
-   :reqtype: Process
-   :security: YES
-   :safety: ASIL_B
-   :derived_from: feat_req__example_feature__example_req
-   :status: valid
-   :version: 1
-   :satisfied_by: comp__mod_temp_component_name_template
+.. code-block:: rst
 
-   The Component shall do xyz to another component to bring it to this condition at this time
+   .. comp_req:: Some Title
+      :id: comp_req__mod_temp_component_name__some_title
+      :reqtype: Process
+      :security: YES
+      :safety: ASIL_B
+      :derived_from: feat_req__example_feature__example_req
+      :status: valid
+      :version: 1
+      :satisfied_by: comp__mod_temp_component_name_template
 
-   Note: (optional, not to be verified)
+      The Component shall do xyz to another component to bring it to this condition at this time
+
+      Note: (optional, not to be verified)
 
 .. attention::
     The above directive must be updated according to your component requirements.


### PR DESCRIPTION
This pull request updates the component architecture and requirements documentation to improve clarity, structure, and correctness. The main changes include replacing custom directives with code blocks for better documentation formatting, updating example component definitions, and clarifying how to document internal components.

**Documentation formatting and structure:**

* Replaced custom `.. comp::` directive with a `.. code-block:: rst` section for static architecture views in `component_architecture.rst` to improve clarity and maintainability.
* Added `.. code-block:: rst` sections for dynamic architecture and functional requirements examples to standardize documentation formatting. [[1]](diffhunk://#diff-6fa6bd4e31207fd9fbf857d9467481bac7b2fa67d3b7b34c34e621f1c5ddcd96R98-R99) [[2]](diffhunk://#diff-6d64716521dd1c2446f9ff4ed9e30bcf34ddeeccc931131a154dc17ca6e07ec8R41-R42)
* Clarified the section on internal components by adding a placeholder and wrapping the example in a code block for consistency.
* Added a blank line after the sequence diagram placeholder for improved readability.

**Example component definition updates:**

* Updated the example component definition in `index.rst` to set `:status:` to valid, update `:implements:` and `:belongs_to:`, and add a `:version:` field, ensuring the example matches current conventions.